### PR TITLE
fix: remove dedicated resources with stop

### DIFF
--- a/cmd/local.go
+++ b/cmd/local.go
@@ -42,8 +42,8 @@ const (
 	FDBImagePath    = "tigrisdata/foundationdb:7.1.7"
 	SearchImagePath = "typesense/typesense:0.23.0"
 
-	volumeName  = "fdbdata"
-	networkName = "tigris_cli_network"
+	volumeName  = "tigris-local-fdbdata"
+	networkName = "tigris-local-network"
 
 	SearchContainerName = "tigris-local-search"
 	FDBContainerName    = "tigris-local-db"
@@ -53,6 +53,15 @@ const (
 var ImageTag = "latest"
 
 var timeout = 10 * time.Second
+
+func removeVolume(cli *client.Client) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	if err := cli.VolumeRemove(ctx, volumeName, true); err != nil {
+		util.Error(err, "error removing docker volume")
+	}
+}
 
 func ensureVolume(cli *client.Client) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
@@ -300,6 +309,8 @@ var serverDownCmd = &cobra.Command{
 		stopContainer(cli, ContainerName)
 		stopContainer(cli, FDBContainerName)
 		stopContainer(cli, SearchContainerName)
+
+		removeVolume(cli)
 
 		fmt.Printf("Tigris stopped\n")
 	},


### PR DESCRIPTION
`tigris local down` does not remove our `fdbdata` volume:

![Screen Shot 2022-06-13 at 2 51 56 PM](https://user-images.githubusercontent.com/8724965/173424217-7da46190-2677-48e1-9954-77882b417693.png)

This PR enforces removal of said volume via an explicit removal function.

Along with the change we are also switching `tigris local` to use dedicated resources.

Regarding the volume, [this option](https://github.com/tigrisdata/tigris-cli/blob/db3def6feb94575297b078db16e9460feaea5fa4/cmd/local.go#L111-L114) made me believe that the volume should have been removed but perhaps it's best to be explicit. However, after checking the [Docker API](https://docs.docker.com/engine/api/v1.41/#operation/ContainerDelete) this option is just to remove anonymous volumes.

