### PR TITLE
fix: Specify the TLS mode explicitly

### DIFF
--- a/client/driver.go
+++ b/client/driver.go
@@ -16,6 +16,7 @@ package client
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"strings"
 
@@ -58,18 +59,19 @@ func Init(config config.Config) error {
 
 	ctx, cancel := util.GetContext(context.Background())
 	defer cancel()
-
-	drv, err := driver.NewDriver(ctx, &cconfig.Driver{
+	cfg := &cconfig.Driver{
 		URL:               url,
 		ApplicationId:     config.ApplicationID,
 		ApplicationSecret: config.ApplicationSecret,
-	})
+	}
+	if config.UseTLS {
+		cfg.TLS = &tls.Config{}
+	}
+	drv, err := driver.NewDriver(ctx, cfg)
 	if err != nil {
 		return err
 	}
-
 	D = drv
-
 	return nil
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -29,12 +29,14 @@ var DefaultConfig = Config{
 	URL:      "localhost:8081",
 	Timeout:  5 * time.Second,
 	Protocol: "grpc",
+	UseTLS:   false,
 }
 
 type Config struct {
 	ApplicationID     string        `json:"application_id" yaml:"application_id" mapstructure:"application_id"`
 	ApplicationSecret string        `json:"application_secret" yaml:"application_secret" mapstructure:"application_secret"`
 	URL               string        `json:"url" yaml:"url"`
+	UseTLS            bool          `json:"use_tls" yaml:"use_tls" mapstructure:"use_tls"`
 	Timeout           time.Duration `json:"timeout" yaml:"timeout"`
 	Protocol          string        `json:"protocol" yaml:"protocol"`
 }


### PR DESCRIPTION
If the remote server supports TLS and without auth - CLI hanged during initialization while trying to connect using plaintext mode on TLS server. This PR fixes that issue by letting user explicitly specify the mode of transport (tls/plaintext) behind a config flag.


```
TIGRIS_USE_TLS=true
```