### PR TITLE
fix: Shutdown tigris container before testing dev start/stop

### DIFF
--- a/tests/db.sh
+++ b/tests/db.sh
@@ -338,6 +338,7 @@ if [ -z "$noup" ]; then
 fi
 
 test_dev_alias() {
+	$cli local down
 	$cli dev start
 	$cli dev stop
 }


### PR DESCRIPTION
fix: Shutdown tigris container before testing dev start/stop to avoid port conflict