### PR TITLE
Add backup command to the CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ pkg/npm/node_modules
 out
 gen
 .tmp
+
+# vscode
+.vscode

--- a/cmd/backup.go
+++ b/cmd/backup.go
@@ -1,0 +1,156 @@
+// Copyright 2022 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/tigrisdata/tigris-cli/client"
+	"github.com/tigrisdata/tigris-cli/util"
+	"github.com/tigrisdata/tigris-client-go/driver"
+)
+
+var (
+	dbFilter         []string
+	collectionFilter []string
+	destDir          string
+	backupTimeout    int
+)
+
+func listDatabases(ctx context.Context) ([]string, error) {
+	databases := []string{}
+
+	resp, err := client.Get().ListDatabases(ctx)
+	if err != nil {
+		return nil, util.Error(err, "list databases")
+	}
+
+	for _, v := range resp {
+		if len(dbFilter) == 0 || util.Contains(dbFilter, v) {
+			databases = append(databases, v)
+		}
+	}
+
+	return databases, nil
+}
+
+func listCollections(ctx context.Context, dbName string) ([]string, error) {
+	collections := []string{}
+
+	resp, err := client.Get().UseDatabase(dbName).ListCollections(ctx)
+	if err != nil {
+		return nil, util.Error(err, "list collections")
+	}
+
+	for _, v := range resp {
+		if len(collectionFilter) == 0 || util.Contains(collectionFilter, v) {
+			collections = append(collections, v)
+		}
+	}
+
+	return collections, nil
+}
+
+func makeDir(dirname string) {
+	if err := os.Mkdir(dirname, 0o700); err != nil {
+		util.Fatal(err, "error creating directory %s", dirname)
+	}
+}
+
+var backupCmd = &cobra.Command{
+	Use:   "backup [filters]",
+	Short: "Dumps documents and schemas to JSON files",
+	Long: `Dumps documents and schemas to JSON files
+	in the current working directory.
+
+	If a database filter is provided it only dumps the schemas of the databases specified.
+	Likewise, collection filters will limit the output to matching collection names.`,
+	Args: cobra.MinimumNArgs(0),
+	Run: func(cmd *cobra.Command, args []string) {
+		withLogin(cmd.Context(), func(_ context.Context) error {
+			util.Stdoutf(" [o] using timeout %d\n", backupTimeout)
+
+			ctx, cancel := context.WithTimeout(context.Background(), time.Duration(backupTimeout)*time.Second)
+			defer cancel()
+
+			databases, err := listDatabases(ctx)
+			if err != nil {
+				return util.Error(err, "list databases")
+			}
+
+			for _, db := range databases {
+				collections, err := listCollections(ctx, db)
+				if err != nil {
+					return util.Error(err, "error listing collections")
+				}
+
+				// Dump schema
+				resp, err := client.Get().DescribeDatabase(ctx, db)
+				if err != nil {
+					return util.Error(err, "describe collection failed")
+				}
+
+				makeDir(destDir)
+				filename := fmt.Sprintf("%s/%s.schema", destDir, db)
+				for _, v := range resp.Collections {
+					err := os.WriteFile(filename, []byte(string(v.Schema)), 0o600)
+					util.Fatal(err, "error writing schema file")
+				}
+				util.Stdoutf(" [.] %s\n", filename)
+
+				for _, collection := range collections {
+					filter, fields := `{}`, `{}`
+					it, err := client.Get().UseDatabase(db).Read(ctx, collection,
+						driver.Filter(filter),
+						driver.Projection(fields),
+						nil,
+					)
+					if err != nil {
+						return util.Error(err, "read failed")
+					}
+					defer it.Close()
+
+					// Dump data
+					filename = fmt.Sprintf("%s/%s.%s.json", destDir, db, collection)
+					var doc driver.Document
+					for it.Next(&doc) {
+						err := os.WriteFile(filename, []byte(string(doc)+"\n"), 0o600)
+						util.Fatal(err, "error writing file %s", filename)
+					}
+
+					util.Stdoutf(" [*] %s\n", filename)
+				}
+			}
+
+			return nil
+		})
+	},
+}
+
+func init() {
+	backupCmd.Flags().StringVarP(&destDir, "directory", "d", "./",
+		"destination directory for backups")
+	backupCmd.Flags().StringSliceVarP(&dbFilter, "databases", "D", []string{},
+		"limit data dump to specified databases")
+	backupCmd.Flags().StringSliceVarP(&collectionFilter, "collections", "C", []string{},
+		"limit data dump to specified collections")
+	backupCmd.Flags().IntVarP(&backupTimeout, "timeout", "t", 3600,
+		"timeout specification in seconds")
+	rootCmd.AddCommand(backupCmd)
+}

--- a/tests/backup.sh
+++ b/tests/backup.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+
+if [ -z "$cli" ]; then
+	cli="./tigris"
+fi
+
+test_backup() {
+  # Settings
+  TESTDIR=testdir
+  TESTDB=backup_test
+  TESTCOLL=backup_test
+  SCHEMAFILE="${TESTDIR}/${TESTDB}.schema"
+  DATAFILE="${TESTDIR}/${TESTDB}.${TESTCOLL}.json"
+
+  # Initialize test database
+  $cli drop database "${TESTDB}" || true
+  $cli create database "${TESTDB}"
+
+  # Add test data
+  cat <<EOF | TIGRIS_LOG_LEVEL=debug $cli import "${TESTDB}" "${TESTCOLL}" --create-collection --primary-key=uuid_field --autogenerate=uuid_field
+{
+	"str_field" : "str_value",
+	"int_field" : 1,
+	"float_field" : 1.1,
+	"uuid_field" : "1ed6ff32-4c0f-4553-9cd3-a2ea3d58e9d1",
+	"time_field" : "2022-11-04T16:17:23.967964263-07:00",
+	"bool_field" : true,
+	"binary_field": "cGVlay1hLWJvbwo=",
+	"objects" : {
+		"str_field" : "str_value",
+		"int_field" : 1,
+		"float_field" : 1.1,
+		"uuid_field" : "1ed6ff32-4c0f-4553-9cd3-a2ea3d58e9d1",
+		"time_field" : "2022-11-04T16:17:23.967964263-07:00",
+		"bool_field" : true,
+		"binary_field": "cGVlay1hLWJvbwo="
+	},
+	"arrays" : [ {
+		"str_field" : "str_value",
+		"int_field" : 1,
+		"float_field" : 1.1,
+		"uuid_field" : "1ed6ff32-4c0f-4553-9cd3-a2ea3d58e9d1",
+		"time_field" : "2022-11-04T16:17:23.967964263-07:00",
+		"bool_field" : true,
+		"binary_field": "cGVlay1hLWJvbwo="
+	} ],
+    "prim_array" : [ "str" ]
+}
+EOF
+
+  $cli backup -d "${TESTDIR}" -D "${TESTDB}"
+  
+  schema_out=$(cat $SCHEMAFILE)
+  data_out=$(cat $DATAFILE)
+
+  schema_expected='{"title":"backup_test","properties":{"arrays":{"type":"array","items":{"type":"object","properties":{"binary_field":{"type":"string","format":"byte"},"bool_field":{"type":"boolean"},"float_field":{"type":"number"},"int_field":{"type":"integer"},"str_field":{"type":"string"},"time_field":{"type":"string","format":"date-time"},"uuid_field":{"type":"string","format":"uuid"}}}},"binary_field":{"type":"string","format":"byte"},"bool_field":{"type":"boolean"},"float_field":{"type":"number"},"int_field":{"type":"integer"},"objects":{"type":"object","properties":{"binary_field":{"type":"string","format":"byte"},"bool_field":{"type":"boolean"},"float_field":{"type":"number"},"int_field":{"type":"integer"},"str_field":{"type":"string"},"time_field":{"type":"string","format":"date-time"},"uuid_field":{"type":"string","format":"uuid"}}},"prim_array":{"type":"array","items":{"type":"string"}},"str_field":{"type":"string"},"time_field":{"type":"string","format":"date-time"},"uuid_field":{"type":"string","format":"uuid","autoGenerate":true}},"primary_key":["uuid_field"]}'
+  data_expected='{
+    "str_field" : "str_value",
+    "int_field" : 1,
+    "float_field" : 1.1,
+    "uuid_field" : "1ed6ff32-4c0f-4553-9cd3-a2ea3d58e9d1",
+    "time_field" : "2022-11-04T16:17:23.967964263-07:00",
+    "bool_field" : true,
+    "binary_field": "cGVlay1hLWJvbwo=",
+    "objects" : {
+      "str_field" : "str_value",
+      "int_field" : 1,
+      "float_field" : 1.1,
+      "uuid_field" : "1ed6ff32-4c0f-4553-9cd3-a2ea3d58e9d1",
+      "time_field" : "2022-11-04T16:17:23.967964263-07:00",
+      "bool_field" : true,
+      "binary_field": "cGVlay1hLWJvbwo="
+    },
+    "arrays" : [ {
+      "str_field" : "str_value",
+      "int_field" : 1,
+      "float_field" : 1.1,
+      "uuid_field" : "1ed6ff32-4c0f-4553-9cd3-a2ea3d58e9d1",
+      "time_field" : "2022-11-04T16:17:23.967964263-07:00",
+      "bool_field" : true,
+      "binary_field": "cGVlay1hLWJvbwo="
+    } ],
+      "prim_array" : [ "str" ]
+  }'
+
+  diff -w -u <(echo "${schema_out}") <(echo "${schema_expected}")
+  diff -w -u <(echo "${data_out}") <(echo "${data_expected}")
+
+  rm -rf "${TESTDIR}"
+}

--- a/tests/db.sh
+++ b/tests/db.sh
@@ -431,12 +431,15 @@ source "$BASEDIR/import.sh"
 main() { 
 	test_config
 
+	# Exercise tests via HTTP
 	unset TIGRIS_PROTOCOL
 	export TIGRIS_URL=localhost:8081
 	db_tests
 	test_scaffold
 	test_import
+	test_backup
 
+	# Exercise tests via GRPC
 	export TIGRIS_URL=localhost:8081
 	export TIGRIS_PROTOCOL=grpc
 	$cli config show | grep "protocol: grpc"
@@ -444,6 +447,7 @@ main() {
 	db_tests
 	test_scaffold
 	test_import
+	test_backup
 
 	export TIGRIS_URL=localhost:8081
 	export TIGRIS_PROTOCOL=http

--- a/util/util.go
+++ b/util/util.go
@@ -134,3 +134,13 @@ func ExecTemplate(w io.Writer, tmpl string, vars interface{}) {
 		_ = Error(err, "execute template failed")
 	}
 }
+
+func Contains(l []string, s string) bool {
+	for _, v := range l {
+		if v == s {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
Adds backup command to the Tigris CLI.

Synopsis:

```
❯ /Users/rbarabas/src/int/tigris-cli/tigris backup -d db1
 [o] using timeout 1h
 [.] ./db1.schema
 [*] ./db1.coll1.json
 [*] ./db1.u15.json
 [*] ./db1.col16.json
 [*] ./db1.coll111.json
 [*] ./db1.t1.json
 [*] ./db1.todoList.json
 [*] ./db1.test_nested_objects_arrays.json
 [*] ./db1.u14.json
 [*] ./db1.users1.json
 [*] ./db1.u16.json
 [*] ./db1.u2.json
 [*] ./db1.u12.json
 
 ❯ /Users/rbarabas/src/int/tigris-cli/tigris backup -d db1,db2 -c u14,u16
 [o] using timeout 1h
 [.] ./db2.schema
 [.] ./db1.schema
 [*] ./db1.u14.json
 [*] ./db1.u16.json
 
 etc.
 ```