### PR TITLE
Refactor the backup command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/viper v1.14.0
 	github.com/stretchr/testify v1.8.1
-	github.com/tigrisdata/tigris-client-go v1.0.0-beta.12
+	github.com/tigrisdata/tigris-client-go v1.0.0-beta.13
 	golang.org/x/net v0.2.0
 	golang.org/x/oauth2 v0.2.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -356,8 +356,8 @@ github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKs
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/subosito/gotenv v1.4.1 h1:jyEFiXpy21Wm81FBN71l9VoMMV8H8jG+qIK3GCpY6Qs=
 github.com/subosito/gotenv v1.4.1/go.mod h1:ayKnFf/c6rvx/2iiLrJUk1e6plDbT3edrFNGqEflhK0=
-github.com/tigrisdata/tigris-client-go v1.0.0-beta.12 h1:zrYdUXtfyqYkIJ6D1F3TTsQU2kY0rrVppGkm/YlfECc=
-github.com/tigrisdata/tigris-client-go v1.0.0-beta.12/go.mod h1:E1wI4sV0uNvDLPyq0l5YZhVLWUod1Vi1FhKf5bRhDeI=
+github.com/tigrisdata/tigris-client-go v1.0.0-beta.13 h1:m6Jnvvd15lem10X85/A2zQfE7pZmL7XbkQnHyxI2sYo=
+github.com/tigrisdata/tigris-client-go v1.0.0-beta.13/go.mod h1:E1wI4sV0uNvDLPyq0l5YZhVLWUod1Vi1FhKf5bRhDeI=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
 github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=


### PR DESCRIPTION
Changes:
- Fixes an issue where the creation of the backup directory was erroneously attempted multiple times. 
- Addresses a panic() that was triggered due to passing `nil` to Read() instead of empty `&driver.ReadOptions{}`.
- Updates command description to indicate its supposed to work on quiesced databases.
- Addresses a panic() that was triggered due to passing `nil` to DescribeDatabase() instead of empty `&driver.DescribeDatabaseOptions{}`.
- Ups tigris-client-go to beta.13
- defer in for loop is trouble in golang, switch to named functions 