### PR TITLE
feat: Application sub commands are associated with project

### DIFF
--- a/cmd/management.go
+++ b/cmd/management.go
@@ -30,16 +30,16 @@ var (
 )
 
 var createApplicationCmd = &cobra.Command{
-	Use:   "application {name} {description}",
-	Short: "Create application credentials",
-	Long: `Creates new application credentials.
+	Use:   "application {project} {name} {description}",
+	Short: "Create application my_project1 my_api_key",
+	Long: `Creates new application credentials for the given project/database.
 The output contains client_id and client_secret,
 which can be used to authenticate using our official client SDKs.
 Set the client_id and client_secret in the configuration of the corresponding SDK
 Check the docs for more information: https://docs.tigrisdata.com/overview/authentication
 `,
 	Example: `
-  tigris create application service1 "main api service"
+  tigris create application my_project1 my_api_key "main api service"
 
   Output:
 
@@ -49,12 +49,13 @@ Check the docs for more information: https://docs.tigrisdata.com/overview/authen
     "description": "main api service",
     "secret": "<client secret here",
     "created_at": 1663802082000,
-    "created_by": "github|3436058"
+    "created_by": "github|3436058",
+    "project": ["<project_name>"]
   }`,
-	Args: cobra.MinimumNArgs(2),
+	Args: cobra.MinimumNArgs(3),
 	Run: func(cmd *cobra.Command, args []string) {
 		withLogin(cmd.Context(), func(ctx context.Context) error {
-			app, err := client.ManagementGet().CreateApplication(ctx, args[0], args[1])
+			app, err := client.ManagementGet().CreateApplication(ctx, args[0], args[1], args[2])
 			if err != nil {
 				return util.Error(err, "create application failed")
 			}
@@ -136,19 +137,21 @@ Output:
 }
 
 var listApplicationsCmd = &cobra.Command{
-	Use:   "applications [name]",
+	Use:   "applications {project} [name]",
 	Short: "Lists applications",
-	Long:  "Lists available applications. Optional parameter allows to return only the application with the given name.",
+	Args:  cobra.MinimumNArgs(1),
+	Long: `Lists available applications for the project. 
+		Optional parameter [name] allows to return only the application with the given name.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		withLogin(cmd.Context(), func(ctx context.Context) error {
-			resp, err := client.ManagementGet().ListApplications(ctx)
+			resp, err := client.ManagementGet().ListApplications(ctx, args[0])
 			if err != nil {
 				return util.Error(err, "list applications failed")
 			}
 
-			if len(args) > 0 {
+			if len(args) > 1 {
 				for _, v := range resp {
-					if v.Name == args[0] {
+					if v.Name == args[1] {
 						err := util.PrettyJSON(v)
 						util.Fatal(err, "list applications filtered")
 					}

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/viper v1.14.0
 	github.com/stretchr/testify v1.8.1
-	github.com/tigrisdata/tigris-client-go v1.0.0-beta.13
+	github.com/tigrisdata/tigris-client-go v1.0.0-beta.14
 	golang.org/x/net v0.2.0
 	golang.org/x/oauth2 v0.2.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -356,8 +356,8 @@ github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKs
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/subosito/gotenv v1.4.1 h1:jyEFiXpy21Wm81FBN71l9VoMMV8H8jG+qIK3GCpY6Qs=
 github.com/subosito/gotenv v1.4.1/go.mod h1:ayKnFf/c6rvx/2iiLrJUk1e6plDbT3edrFNGqEflhK0=
-github.com/tigrisdata/tigris-client-go v1.0.0-beta.13 h1:m6Jnvvd15lem10X85/A2zQfE7pZmL7XbkQnHyxI2sYo=
-github.com/tigrisdata/tigris-client-go v1.0.0-beta.13/go.mod h1:E1wI4sV0uNvDLPyq0l5YZhVLWUod1Vi1FhKf5bRhDeI=
+github.com/tigrisdata/tigris-client-go v1.0.0-beta.14 h1:lZ4WbH5PREpMQqIr6zgUcbze8e5wpyJdos46A0aWxYQ=
+github.com/tigrisdata/tigris-client-go v1.0.0-beta.14/go.mod h1:E1wI4sV0uNvDLPyq0l5YZhVLWUod1Vi1FhKf5bRhDeI=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
 github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=


### PR DESCRIPTION
Newer usage

```
tigris create application --help
Creates new application credentials for the given project/database.
The output contains client_id and client_secret,
which can be used to authenticate using our official client SDKs.
Set the client_id and client_secret in the configuration of the corresponding SDK
Check the docs for more information: https://docs.tigrisdata.com/overview/authentication

Usage:
  tigris create application {project} {name} {description} [flags]

Examples:

  tigris create application my_project1 my_api_key "main api service"

  Output:

  {
    "id": "<client id here>",
    "name": "service2",
    "description": "main api service",
    "secret": "<client secret here",
    "created_at": 1663802082000,
    "created_by": "github|3436058",
    "project": ["<project_name>"]
  }

Flags:
  -h, --help   help for application

```

Server will soon have RBAC and granular permission modeling. Once it is in place server-side, application will be scoped to project.