### PR TITLE
feat: add restore cmd, improve backup

### DIFF
--- a/cmd/backup.go
+++ b/cmd/backup.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"time"
 
+	units "github.com/docker/go-units"
 	"github.com/spf13/cobra"
 	"github.com/tigrisdata/tigris-cli/client"
 	"github.com/tigrisdata/tigris-cli/util"
@@ -28,14 +29,19 @@ import (
 )
 
 var (
-	dbFilter         []string
-	collectionFilter []string
-	destDir          string
-	backupTimeout    int
+	projectFilter       []string
+	collectionFilter    []string
+	destDir             string
+	backupTimeout       int
+	verboseBackup       bool
+	backupFileExtension = "backup"
+	schemaFileExtension = "schema"
 )
 
+// listProjects returns the projects/databases available in Tigris as a string array
+// but filters the output using the filters specified via the command line.
 func listProjects(ctx context.Context) ([]string, error) {
-	var projects []string
+	projects := make([]string, 0)
 
 	resp, err := client.Get().ListDatabases(ctx)
 	if err != nil {
@@ -43,7 +49,7 @@ func listProjects(ctx context.Context) ([]string, error) {
 	}
 
 	for _, v := range resp {
-		if len(dbFilter) == 0 || util.Contains(dbFilter, v) {
+		if len(projectFilter) == 0 || util.Contains(projectFilter, v) {
 			projects = append(projects, v)
 		}
 	}
@@ -51,8 +57,10 @@ func listProjects(ctx context.Context) ([]string, error) {
 	return projects, nil
 }
 
+// listCollections enumerates the collections available in Tigris as a string array
+// but filters the output using the filters specified via the command line.
 func listCollections(ctx context.Context, dbName string) ([]string, error) {
-	collections := []string{}
+	collections := make([]string, 0)
 
 	resp, err := client.Get().UseDatabase(dbName).ListCollections(ctx)
 	if err != nil {
@@ -68,78 +76,97 @@ func listCollections(ctx context.Context, dbName string) ([]string, error) {
 	return collections, nil
 }
 
-func writeCollection(ctx context.Context, db, collection string) error {
-	var doc driver.Document
+// writeCollection downloads the data of a collection from Tigris and stores it
+// in a file post-fixed with backupFileExtension. The function returns the bytes
+// written and an error, if applicable.
+func writeCollection(ctx context.Context, db, collection, file string) (int, error) {
+	var (
+		doc   driver.Document
+		bytes int
+	)
 
 	it, err := client.Get().UseDatabase(db).Read(ctx, collection,
 		driver.Filter(`{}`),
 		driver.Projection(`{}`),
 	)
 	if err != nil {
-		return util.Error(err, "read failed")
+		return bytes, util.Error(err, "read failed")
 	}
 	defer it.Close()
 
-	filename := fmt.Sprintf("%s/%s.%s.json", destDir, db, collection)
-
-	f, err := os.Create(filename)
+	f, err := os.Create(file)
 	if err != nil {
-		return util.Error(err, "failed writing file")
+		return bytes, util.Error(err, "failed writing file")
 	}
 
 	writer := bufio.NewWriter(f)
 	for it.Next(&doc) {
-		_, err := writer.WriteString(string(doc) + "\n")
-		util.Fatal(err, "error writing file %s", filename)
+		b, err := writer.WriteString(string(doc) + "\n")
+		bytes += b
+
+		util.Fatal(err, "error writing file %s", file)
 	}
 
 	if err = writer.Flush(); err != nil {
-		return util.Error(err, "failed to flush file")
+		return bytes, util.Error(err, "failed to flush file")
 	}
 
 	if err = f.Close(); err != nil {
-		return util.Error(err, "failed to close file")
+		return bytes, util.Error(err, "failed to close file")
 	}
 
-	util.Stdoutf(" [*] %s\n", filename)
-
-	return nil
+	return bytes, nil
 }
 
-func writeSchema(ctx context.Context, db string) error {
+// writeSchema downloads the schema of all collections related to the database
+// specified and stores in the file specified.
+func writeSchema(ctx context.Context, db, file string) (int, error) {
+	var bytes int
+
 	resp, err := client.Get().DescribeDatabase(ctx, db)
 	if err != nil {
-		return util.Error(err, "describe collection failed")
+		return bytes, util.Error(err, "describe collection failed")
 	}
 
-	filename := fmt.Sprintf("%s/%s.schema", destDir, db)
+	f, err := os.Create(file)
+	if err != nil {
+		return bytes, util.Error(err, "failed writing file")
+	}
+
+	writer := bufio.NewWriter(f)
 	for _, v := range resp.Collections {
-		err := os.WriteFile(filename, []byte(string(v.Schema)), 0o600)
-		return util.Error(err, "error writing schema file")
+		b, err := writer.WriteString(string(v.Schema) + "\n")
+		bytes += b
+
+		if err != nil {
+			return bytes, util.Error(err, "error writing schema file")
+		}
 	}
 
-	util.Stdoutf(" [.] %s\n", filename)
+	if err = writer.Flush(); err != nil {
+		return bytes, util.Error(err, "failed to flush file")
+	}
 
-	return nil
+	if err = f.Close(); err != nil {
+		return bytes, util.Error(err, "failed to close file")
+	}
+
+	return bytes, nil
 }
 
-func createBackupDir(dirname string) error {
-	util.Stdoutf(" [i] ensuring backup dir exists %s\n", destDir)
-
-	if err := os.Mkdir(dirname, 0o700); err != nil {
-		return util.Error(err, "error creating directory %s", dirname)
+func printStats(start time.Time, bytes float64) {
+	if verboseBackup {
+		stop := time.Since(start).Seconds()
+		util.Stdoutf(" [>] %s (%s/s in %.1fs)\n", units.HumanSize(bytes), units.HumanSize(bytes/stop), stop)
 	}
-
-	return nil
 }
 
 var backupCmd = &cobra.Command{
 	Use:   "backup [filters]",
-	Short: "Dumps documents and schemas to JSON files on a quiesced database",
-	Long: `Dumps documents and schemas to JSON files on a quiesced database
-	into the directory specified in the argument.
+	Short: "Dumps documents and schemas to JSON files",
+	Long: `Dumps documents and schemas to JSON files into the directory specified in the argument.
 
-	If a database filter is provided it only dumps the schemas of the databases specified.
+	If a project name filter is provided it only dumps the schemas of the projects specified.
 	Likewise, collection filters will limit the output to matching collection names.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		withLogin(cmd.Context(), func(_ context.Context) error {
@@ -152,23 +179,33 @@ var backupCmd = &cobra.Command{
 				return util.Error(err, "failed to list projects")
 			}
 
-			if err := createBackupDir(destDir); err != nil {
+			if err := os.Mkdir(destDir, 0o700); err != nil {
 				return util.Error(err, "failed to create backup dir")
 			}
 
 			for _, db := range projects {
-				if err := writeSchema(ctx, db); err != nil {
+				path := fmt.Sprintf("%s/%s.%s", destDir, db, schemaFileExtension)
+				util.Stdoutf(" [.] %s\n", path)
+				start := time.Now()
+				bytes, err := writeSchema(ctx, db, path)
+				if err != nil {
 					return util.Error(err, "failed to write schema")
 				}
+				printStats(start, float64(bytes))
 
 				collections, err := listCollections(ctx, db)
 				if err != nil {
 					return util.Error(err, "error listing collections")
 				}
 				for _, collection := range collections {
-					if err := writeCollection(ctx, db, collection); err != nil {
+					start := time.Now()
+					path := fmt.Sprintf("%s/%s.%s.%s", destDir, db, collection, backupFileExtension)
+					util.Stdoutf(" [*] %s\n", path)
+					bytes, err := writeCollection(ctx, db, collection, path)
+					if err != nil {
 						return util.Error(err, "failed to write collection")
 					}
+					printStats(start, float64(bytes))
 				}
 			}
 
@@ -180,11 +217,13 @@ var backupCmd = &cobra.Command{
 func init() {
 	backupCmd.Flags().StringVarP(&destDir, "directory", "d", "./tigris-backup",
 		"destination directory for backups")
-	backupCmd.Flags().StringSliceVarP(&dbFilter, "projects", "P", []string{},
+	backupCmd.Flags().StringSliceVarP(&projectFilter, "projects", "P", []string{},
 		"limit data dump to specified projects")
 	backupCmd.Flags().StringSliceVarP(&collectionFilter, "collections", "C", []string{},
 		"limit data dump to specified collections")
 	backupCmd.Flags().IntVarP(&backupTimeout, "timeout", "t", 3600,
 		"timeout specification in seconds")
+	backupCmd.Flags().BoolVarP(&verboseBackup, "verbose", "v", false,
+		"verbose output")
 	rootCmd.AddCommand(backupCmd)
 }

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -1,0 +1,285 @@
+// Copyright 2022 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+	"unsafe"
+
+	"github.com/spf13/cobra"
+	"github.com/tigrisdata/tigris-cli/client"
+	"github.com/tigrisdata/tigris-cli/util"
+	"github.com/tigrisdata/tigris-client-go/driver"
+)
+
+var (
+	srcDir         string
+	dbPrefix       string
+	dbPostfix      string
+	dbSeparator    string
+	restoreTimeout int
+)
+
+func amendDatabaseName(dbname string) string {
+	var tags []string
+
+	if dbPrefix != "" {
+		tags = append(tags, dbPrefix)
+	}
+
+	tags = append(tags, dbname)
+
+	if dbPostfix != "" {
+		tags = append(tags, dbPostfix)
+	}
+
+	return strings.Join(tags, dbSeparator)
+}
+
+func findDatabases() ([]string, error) {
+	databases := make([]string, 0)
+
+	entries, err := os.ReadDir(srcDir)
+	if err != nil {
+		return nil, util.Error(err, "error reading directory")
+	}
+
+	// See if db names need to be filtered
+	dbPattern := `.*`
+	if len(projectFilter) > 0 {
+		dbPattern = strings.Join(projectFilter, "|")
+	}
+
+	// Obtain database names from schema files
+	schemaPattern := fmt.Sprintf(
+		`^(?P<name>(%s))[.]%s$`,
+		dbPattern,
+		schemaFileExtension)
+	re := regexp.MustCompile(schemaPattern)
+
+	for _, v := range entries {
+		if v.IsDir() {
+			continue
+		}
+
+		// Extract database name from filename
+		match := re.FindStringSubmatch(v.Name())
+		if len(match) == 0 {
+			continue
+		}
+
+		databases = append(databases, match[1])
+	}
+
+	return databases, nil
+}
+
+func findCollections(db string) ([]string, error) {
+	collections := make([]string, 0)
+
+	entries, err := os.ReadDir(srcDir)
+	if err != nil {
+		return nil, util.Error(err, "error reading directory")
+	}
+
+	// See if collections need to be filtered
+	collPattern := `.*`
+	if len(collectionFilter) > 0 {
+		collPattern = strings.Join(collectionFilter, "|")
+	}
+
+	// Obtain schema names from json files
+	backupPattern := fmt.Sprintf(
+		`^%s[.](?P<collection>(%s))[.]%s$`,
+		db,
+		collPattern,
+		backupFileExtension)
+	re := regexp.MustCompile(backupPattern)
+
+	for _, v := range entries {
+		if v.IsDir() {
+			continue
+		}
+
+		// Extract database name from filename
+		match := re.FindStringSubmatch(v.Name())
+		if len(match) == 0 {
+			continue
+		}
+
+		collections = append(collections, match[1])
+	}
+
+	return collections, nil
+}
+
+func createDatabase(ctx context.Context, db string) error {
+	err := client.Get().CreateDatabase(ctx, db)
+	return util.Error(err, "create database")
+}
+
+func restoreDatabase(ctx context.Context, db, path string) error {
+	docs := make([]json.RawMessage, 0)
+
+	f, err := os.Open(path)
+	if err != nil {
+		return util.Error(err, "failed to read schema")
+	}
+	defer f.Close()
+
+	dec := json.NewDecoder(f)
+	for dec.More() {
+		var v json.RawMessage
+		err := dec.Decode(&v)
+		util.Fatal(err, "reading documents from stream of documents")
+
+		docs = append(docs, v)
+	}
+
+	restoreDB := amendDatabaseName(db)
+	if err := createDatabase(ctx, restoreDB); err != nil {
+		return util.Error(err, "create database failed")
+	}
+
+	return client.Transact(ctx, restoreDB, func(ctx context.Context, tx driver.Tx) error {
+		for _, v := range docs {
+			if err := createCollection(ctx, tx, driver.Schema(v)); err != nil {
+				return util.Error(err, "failed to create collection")
+			}
+		}
+
+		return nil
+	})
+}
+
+func restoreCollection(ctx context.Context, db, collection, path string) error {
+	docs := make([]json.RawMessage, 0)
+
+	f, err := os.Open(path)
+	if err != nil {
+		return util.Error(err, "failed to read collection")
+	}
+	defer f.Close()
+
+	dec := json.NewDecoder(f)
+	for dec.More() {
+		var v json.RawMessage
+		err := dec.Decode(&v)
+		util.Fatal(err, "reading documents from stream of documents")
+
+		docs = append(docs, v)
+	}
+
+	if len(docs) == 0 {
+		return nil
+	}
+
+	restoreDB := amendDatabaseName(db)
+
+	return client.Transact(ctx, restoreDB, func(ctx context.Context, tx driver.Tx) error {
+		ptr := unsafe.Pointer(&docs)
+		_, err := client.Get().UseDatabase(restoreDB).Insert(ctx, collection, *(*[]driver.Document)(ptr))
+		if err != nil {
+			return util.Error(err, "failed to insert doc")
+		}
+
+		return nil
+	})
+}
+
+var restoreCmd = &cobra.Command{
+	Use:   "restore [filters]",
+	Short: "restores documents and schemas from JSON files",
+	Long: `restores documents and schemas from JSON files in a directory specified in the argument.
+
+	If a database filter is provided it only restores the schemas of the databases specified.
+	Likewise, collection filters will limit the input to matching collection names.
+
+	SYNOPSIS
+
+	Restore all the data and schema with the same name as they were captured:
+	$ tigris restore -d /path/to/backup
+
+	Restore a single project called mydb:
+	$ tigris restore -d /path/to/backup -P mydb
+
+	Restore mydb project under the name mydb_restored:
+	$ tigris restore -d /path/to/backup -P mydb -e restored
+
+	Restore mydb as restored.mydb:
+	$ tigris restore -d /path/to/backup -P mydb -b restored -s '.'
+
+	`,
+	Args: cobra.MinimumNArgs(0),
+	Run: func(cmd *cobra.Command, args []string) {
+		withLogin(cmd.Context(), func(_ context.Context) error {
+			util.Stdoutf(" [i] using timeout %d\n", restoreTimeout)
+			ctx, cancel := context.WithTimeout(context.Background(), time.Duration(restoreTimeout)*time.Second)
+			defer cancel()
+
+			databases, err := findDatabases()
+			if err != nil {
+				return util.Error(err, "failed to find databases")
+			}
+
+			for _, db := range databases {
+				util.Stdoutf(" [*] %s\n", db)
+				file := fmt.Sprintf("%s/%s.%s", srcDir, db, schemaFileExtension)
+				if err = restoreDatabase(ctx, db, file); err != nil {
+					return util.Error(err, "failed to restore database")
+				}
+
+				collections, err := findCollections(db)
+				if err != nil {
+					return util.Error(err, "failed to find collections")
+				}
+
+				for _, collection := range collections {
+					util.Stdoutf(" [.] %s => %s\n", db, collection)
+					file := fmt.Sprintf("%s/%s.%s.%s", srcDir, db, collection, backupFileExtension)
+					if err = restoreCollection(ctx, db, collection, file); err != nil {
+						return util.Error(err, "failed to restore collection")
+					}
+				}
+			}
+
+			return nil
+		})
+	},
+}
+
+func init() {
+	restoreCmd.Flags().StringVarP(&srcDir, "directory", "d", "./tigris-backup",
+		"input file directory")
+	restoreCmd.Flags().StringVarP(&dbPrefix, "prefix", "b", "",
+		"prefixes restored database names")
+	restoreCmd.Flags().StringVarP(&dbPostfix, "postfix", "e", "",
+		"postfixes restored database names")
+	restoreCmd.Flags().StringVarP(&dbSeparator, "separator", "s", "_",
+		"separator to use for pre and postfixes")
+	restoreCmd.Flags().StringSliceVarP(&projectFilter, "projects", "P", []string{},
+		"limit data restore to specified projects")
+	restoreCmd.Flags().StringSliceVarP(&collectionFilter, "collections", "C", []string{},
+		"limit data restore to specified collections")
+	restoreCmd.Flags().IntVarP(&restoreTimeout, "timeout", "t", 3600,
+		"timeout specification in seconds")
+	rootCmd.AddCommand(restoreCmd)
+}

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -1,0 +1,43 @@
+// Copyright 2022 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestContains(t *testing.T) {
+	tests := []struct {
+		list []string
+		item string
+		want bool
+	}{
+		{
+			list: []string{"Hello", "Tigris", "Community"},
+			item: "Tigris",
+			want: true,
+		},
+		{
+			list: []string{"Hello", "Tigris", "Community"},
+			item: "World",
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, Contains(tt.list, tt.item), tt.want)
+	}
+}


### PR DESCRIPTION
Changes:
- feat: Add restore command to cli, as a counterpart of backup.
- feat: add optional verbosity switch to `backup` output
- feat: timing and download rate info in verbose `backup`
- fix: truncated schema in `backup`
- chore: comments added to functions in `backup`
- chore: add some util tests

```
❯ ./tigris backup -d /tmp/benchmark -v
 [i] using timeout 3600
 [.] /tmp/benchmark/backup_test.schema
 [>] 1.073kB (9.372kB/s in 0.1s)
 [*] /tmp/benchmark/backup_test.backup_test.backup
 [>] 800B (7.113kB/s in 0.1s)
 [.] /tmp/benchmark/tigris_starter_ts.schema
 [>] 911B (7.826kB/s in 0.1s)
 [*] /tmp/benchmark/tigris_starter_ts.orders.backup
 [>] 0B (0B/s in 0.1s)
 [*] /tmp/benchmark/tigris_starter_ts.products.backup
 [>] 136B (1.169kB/s in 0.1s)
 [*] /tmp/benchmark/tigris_starter_ts.users.backup
 [>] 387B (3.424kB/s in 0.1s)
 [.] /tmp/benchmark/ycsb_tigris.schema
 [>] 545B (4.753kB/s in 0.1s)
 [*] /tmp/benchmark/ycsb_tigris.user_tables.backup
 ...
 ```
 
 Restore:
```
❯ ./tigris delete-project db1_restored && make && ./tigris restore -d /tmp/benchmark --postfix restored -P db1

Are you sure you want to delete the project? (y/n)y
CGO_ENABLED=0 go build -tags=release -ldflags "-w -extldflags '-static' -X 'github.com/tigrisdata/tigris-cli/util.Version=v1.0.0-alpha.7-89-g4180ecd'" -o tigris  .
 [i] using timeout 3600
 [*] db1
 [.] db1 => ffr
 [.] db1 => sorted_collection
 [.] db1 => test_nested_objects_arrays
 [.] db1 => u2
 [.] db1 => u3
 [.] db1 => user1
...

❯ ./tigris read --project db1_restored u2
{"strName":"121","id":1}
{"strName":"fr","id":2}
```
 