### PR TITLE
Command to login to locally running instance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ lint:
 	golangci-lint run --timeout=3m --fix
 	shellcheck tests/*.sh
 	cd pkg/npm && TIGRIS_SKIP_VERIFY=1 npm i; npx eslint install.js
+	git checkout pkg/npm/bin/tigris # lints above overwrites placeholder with real binary
 
 go.sum: go.mod
 	go mod download

--- a/tests/main.sh
+++ b/tests/main.sh
@@ -302,23 +302,23 @@ error() {
 db_errors_tests() {
 	$cli list projects
 
-	error "database doesn't exist 'db2'" $cli delete-project -f db2
+	error "project doesn't exist 'db2'" $cli delete-project -f db2
 
-	error "database doesn't exist 'db2'" $cli drop collection --project=db2 coll1
+	error "project doesn't exist 'db2'" $cli drop collection --project=db2 coll1
 
-	error "database doesn't exist 'db2'" $cli create collection --project=db2 \
+	error "project doesn't exist 'db2'" $cli create collection --project=db2 \
 		'{ "title" : "coll1", "properties": { "Key1": { "type": "string" }, "Field1": { "type": "integer" }, "Field2": { "type": "integer" } }, "primary_key": ["Key1"] }'
 
-	error "database doesn't exist 'db2'" $cli list collections --project=db2
+	error "project doesn't exist 'db2'" $cli list collections --project=db2
 
-	error "database doesn't exist 'db2'" $cli insert --project=db2 coll1 '{}'
+	error "project doesn't exist 'db2'" $cli insert --project=db2 coll1 '{}'
 
-	error "database doesn't exist 'db2'" $cli read --project=db2 coll1 '{}' ||
+	error "project doesn't exist 'db2'" $cli read --project=db2 coll1 '{}' ||
 	error "404 Not Found" $cli read --project=db2 coll1 '{}'
 
-	error "database doesn't exist 'db2'" $cli update --project=db2 coll1 '{}' '{}'
+	error "project doesn't exist 'db2'" $cli update --project=db2 coll1 '{}' '{}'
 
-	error "database doesn't exist 'db2'" $cli delete --project=db2 coll1 '{}'
+	error "project doesn't exist 'db2'" $cli delete --project=db2 coll1 '{}'
 
 	$cli create project db2
 	error "collection doesn't exist 'coll1'" $cli insert --project=db2 coll1 '{}'


### PR DESCRIPTION
Allow to easily point all subsequent Tigris commands to the locally running instance.

Usage:

```
tigris login dev
tigris login localhost
tigris login localhost:9091
```

It clears credentals in the config file and sets URL to localhost.