### PR TITLE
fix: Fixed crash on importing null values

### DIFF
--- a/cmd/import.go
+++ b/cmd/import.go
@@ -50,7 +50,7 @@ func evolveSchema(ctx context.Context, db string, coll string, docs []json.RawMe
 	util.Fatal(err, "infer schema")
 
 	b, err := json.Marshal(sch)
-	util.Fatal(err, "marshal schema")
+	util.Fatal(err, "marshal schema: %s", string(b))
 
 	err = client.Get().UseDatabase(db).CreateOrUpdateCollection(ctx, coll, b)
 


### PR DESCRIPTION
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x98 pc=0xcf0881]

goroutine 1 [running]:
github.com/tigrisdata/tigris-cli/schema.translateType({0x0, 0x0})
	/home/firs/work/develop/go/src/github.com/tigrisdata/tigris-cli/schema/inference.go:110 +0x61
github.com/tigrisdata/tigris-cli/schema.traverseFields(0xc00012e000?, 0xe01d80?, {0x184cb58, 0x0, 0x46ebde?})
	/home/firs/work/develop/go/src/github.com/tigrisdata/tigris-cli/schema/inference.go:247 +0xdb
github.com/tigrisdata/tigris-cli/schema.docToSchema(0x181bc40, {0x7ffdd32faffc, 0xb}, {0xc00002c018, 0x15, 0x18}, {0xc000702570, 0x1, 0x1}, {0x184cb58, ...})
	/home/firs/work/develop/go/src/github.com/tigrisdata/tigris-cli/schema/inference.go:314 +0x1e5
github.com/tigrisdata/tigris-cli/schema.Infer(0x0?, {0x7ffdd32faffc, 0xb}, {0xc00012a230, 0x2, 0x11375e0?}, {0xc000702570, 0x1, 0x1}, {0x184cb58, ...}, ...)
	/home/firs/work/develop/go/src/github.com/tigrisdata/tigris-cli/schema/inference.go:332 +0x12c
github.com/tigrisdata/tigris-cli/cmd.evolveSchema({0x11375e0, 0xc000042148}, {0x7ffdd32fafed, 0xe}, {0x7ffdd32faffc, 0xb}, {0xc00012a230?, 0x2, 0xc00012a230?})
	/home/firs/work/develop/go/src/github.com/tigrisdata/tigris-cli/cmd/import.go:49 +0xef
github.com/tigrisdata/tigris-cli/cmd.glob..func17.1.1({0x11375e0, 0xc000042148}, {0xc0000aa120, 0x3, 0xc00007e800?}, {0xc00012a230, 0x2, 0x3})
```