### PR TITLE
fix: add missing env vars to .env scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Create databases and collections, read and write data, perform transactions,
 stream events and setup Tigris locally, all from the command line.
 
 # Documentation
+
 - [Quickstart](https://docs.tigrisdata.com/quickstart/with-cli)
 - [Working Locally](https://docs.tigrisdata.com/cli/working-locally)
 - [Command Reference](https://docs.tigrisdata.com/cli)
@@ -20,7 +21,9 @@ The tigris CLI tool can be installed as follows:
 ```shell
 curl -sSL https://tigris.dev/cli-macos | sudo tar -xz -C /usr/local/bin
 ```
+
 or
+
 ```shell
 brew install tigrisdata/tigris/tigris-cli
 ```
@@ -30,12 +33,15 @@ brew install tigrisdata/tigris/tigris-cli
 ```shell
 curl -sSL https://tigris.dev/cli-linux | sudo tar -xz -C /usr/local/bin
 ```
+
 or
+
 ```shell
 sudo snap install tigris
 ```
 
 ## Cross-platform using NPM
+
 ```shell
 sudo npm i -g @tigrisdata/tigris-cli
 ```
@@ -156,5 +162,13 @@ tigris transact --project=test \
 tigris local down
 ```
 
+# Development
+
+For `make lint` will need the following installed:
+
+- [golangci-lint](https://github.com/golangci/golangci-lint)
+- [shellcheck](https://github.com/koalaman/shellcheck)
+
 # License
+
 This software is licensed under the [Apache 2.0](LICENSE).

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
 	"github.com/tigrisdata/tigris-cli/client"
@@ -118,16 +119,22 @@ func writeEnvFile(ctx context.Context, proj string) {
 		DatabaseBranchName: "main",
 	})
 
-	f, err := os.Create(".env")
-	util.Fatal(err, "create .env file")
+	envFilePath := filepath.Join(outDir, ".env")
+	util.Infof("Writing .env to '%s'", envFilePath)
+
+	err = os.MkdirAll(outDir, 0o755)
+	util.Fatal(err, "MkdirAll: %s", outDir)
+
+	f, err := os.Create(envFilePath)
+	util.Fatal(err, "create "+envFilePath+" file")
 
 	_, err = f.Write(buf.Bytes())
-	util.Fatal(err, "write .env file")
+	util.Fatal(err, "write "+envFilePath+" file")
 
 	err = f.Close()
-	util.Fatal(err, "close .env file")
+	util.Fatal(err, "close "+envFilePath+" file")
 
-	util.Infof("Written .env file")
+	util.Infof("Written " + envFilePath + " file")
 }
 
 var createProjectCmd = &cobra.Command{

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -111,9 +111,11 @@ func writeEnvFile(ctx context.Context, proj string) {
 
 	buf := bytes.Buffer{}
 	util.ExecTemplate(&buf, templates.DotEnv, &scaffold.TmplVars{
-		ClientID:     clientID,
-		ClientSecret: clientSecret,
-		URL:          config.DefaultConfig.URL,
+		ClientID:     			clientID,
+		ClientSecret: 			clientSecret,
+		URL:          			config.DefaultConfig.URL,
+		ProjectName: 				proj,
+		DatabaseBranchName: "main",
 	})
 
 	f, err := os.Create(".env")

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -111,10 +111,10 @@ func writeEnvFile(ctx context.Context, proj string) {
 
 	buf := bytes.Buffer{}
 	util.ExecTemplate(&buf, templates.DotEnv, &scaffold.TmplVars{
-		ClientID:     			clientID,
-		ClientSecret: 			clientSecret,
-		URL:          			config.DefaultConfig.URL,
-		ProjectName: 				proj,
+		ClientID:           clientID,
+		ClientSecret:       clientSecret,
+		URL:                config.DefaultConfig.URL,
+		ProjectName:        proj,
 		DatabaseBranchName: "main",
 	})
 

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -116,7 +116,7 @@ func writeEnvFile(ctx context.Context, proj string) {
 		ClientSecret:       clientSecret,
 		URL:                config.DefaultConfig.URL,
 		ProjectName:        proj,
-		DatabaseBranchName: "main",
+		DatabaseBranchName: config.DefaultConfig.Branch,
 	})
 
 	envFilePath := filepath.Join(outDir, ".env")

--- a/scaffold/scaffold.go
+++ b/scaffold/scaffold.go
@@ -70,14 +70,15 @@ type Config struct {
 }
 
 type TmplVars struct {
-	URL              string
-	Collections      []Collection
-	Collection       Collection
-	ProjectName      string
-	ProjectNameCamel string
-	PackageName      string
-	ClientID         string
-	ClientSecret     string
+	URL              		string
+	Collections      		[]Collection
+	Collection       		Collection
+	ProjectName      		string
+	ProjectNameCamel 		string
+	PackageName      		string
+	ClientID         		string
+	ClientSecret     		string
+	DatabaseBranchName	string
 }
 
 type JSONToLangType interface {

--- a/scaffold/scaffold.go
+++ b/scaffold/scaffold.go
@@ -70,15 +70,15 @@ type Config struct {
 }
 
 type TmplVars struct {
-	URL              		string
-	Collections      		[]Collection
-	Collection       		Collection
-	ProjectName      		string
-	ProjectNameCamel 		string
-	PackageName      		string
-	ClientID         		string
-	ClientSecret     		string
-	DatabaseBranchName	string
+	URL                string
+	Collections        []Collection
+	Collection         Collection
+	ProjectName        string
+	ProjectNameCamel   string
+	PackageName        string
+	ClientID           string
+	ClientSecret       string
+	DatabaseBranchName string
 }
 
 type JSONToLangType interface {

--- a/templates/scaffold/typescript/.env
+++ b/templates/scaffold/typescript/.env
@@ -10,3 +10,9 @@ TIGRIS_URI={{.URL}}
 # See: https://docs.tigrisdata.com/auth
 TIGRIS_CLIENT_ID={{.ClientID}}
 TIGRIS_CLIENT_SECRET={{.ClientSecret}}
+
+# The name of the project in Tigris
+TIGRIS_PROJECT={{.ProjectName}}
+
+# The database branch to be used e.g. main, develop, feature-name
+TIGRIS_DB_BRANCH={{.DatabaseBranchName}}


### PR DESCRIPTION
Adds the following environmental variables to the `.env` template used when running:

```sh
tigris create project {project_name} --create-env-vars
```

Missing env vars are:

- `TIGRIS_PROJECT`: the project name
- `TIGRIS_DB_BRANCH`: the name of the database branch

Creating a draft PR as these are the first lines of Go I've written in my life. I've built the CLI and tested the new functionality works manually, but I haven't run any of the tests as I wasn't sure how to do that

edit: ah, `make test` 😊. But there seem to be several other dependencies that need to be in place before running the tests locally.