### PR TITLE
Fix data import

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ ifeq ($(GOOS), windows)
 BIN=tigris.exe
 endif
 
-BUILD_PARAM=-tags=release -ldflags "-w -extldflags '-static' -X 'github.com/tigrisdata/tigris-cli/util.Version=$(VERSION)'" -o ${BIN} $(shell printenv BUILD_PARAM)
+BUILD_PARAM=-tags=release -ldflags "-s -w -extldflags '-static' -X 'github.com/tigrisdata/tigris-cli/util.Version=$(VERSION)'" -o ${BIN} $(shell printenv BUILD_PARAM)
 TEST_PARAM=-cover -race -tags=test $(shell printenv TEST_PARAM)
 
 all: ${BIN}

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -178,6 +178,15 @@ func init() {
 	importCmd.Flags().StringVar(&CSVComment, "csv-comment", "",
 		"CSV comment")
 
+	importCmd.Flags().BoolVar(&schema.DetectByteArrays, "detect-byte-arrays", false,
+		"Try detect byte arrays fields")
+	importCmd.Flags().BoolVar(&schema.DetectUUIDs, "detect-uuids", true,
+		"Try detect UUID fields")
+	importCmd.Flags().BoolVar(&schema.DetectTimes, "detect-times", true,
+		"Try detect date time fields")
+	importCmd.Flags().BoolVar(&schema.DetectIntegers, "detect-integers", true,
+		"Try detect integer fields")
+
 	addProjectFlag(importCmd)
 	rootCmd.AddCommand(importCmd)
 }

--- a/cmd/search/import.go
+++ b/cmd/search/import.go
@@ -172,6 +172,15 @@ func init() {
 	importCmd.Flags().BoolVar(&NoCreate, "no-create-index", false,
 		"Do not create collection automatically if it doesn't exist")
 
+	importCmd.Flags().BoolVar(&schema.DetectByteArrays, "detect-byte-arrays", false,
+		"Try to detect byte arrays fields")
+	importCmd.Flags().BoolVar(&schema.DetectUUIDs, "detect-uuids", true,
+		"Try to detect UUID fields")
+	importCmd.Flags().BoolVar(&schema.DetectTimes, "detect-times", true,
+		"Try to detect date time fields")
+	importCmd.Flags().BoolVar(&schema.DetectIntegers, "detect-integers", true,
+		"Try to detect integer fields")
+
 	importCmd.Flags().StringVar(&CSVDelimiter, "csv-delimiter", "",
 		"CSV delimiter")
 	importCmd.Flags().BoolVar(&CSVTrimLeadingSpace, "csv-trim-leading-space", true,

--- a/schema/inference.go
+++ b/schema/inference.go
@@ -45,6 +45,11 @@ const (
 )
 
 var (
+	DetectByteArrays = false
+	DetectUUIDs      = true
+	DetectTimes      = true
+	DetectIntegers   = true
+
 	ErrIncompatibleSchema = fmt.Errorf("error incompatible schema")
 	ErrExpectedString     = fmt.Errorf("expected string type")
 	ErrExpectedNumber     = fmt.Errorf("expected json.Number")
@@ -61,25 +66,29 @@ func parseDateTime(s string) bool {
 	return false
 }
 
+func parseNumber(v any) (string, string, error) {
+	n, ok := v.(json.Number)
+	if !ok {
+		return "", "", ErrExpectedNumber
+	}
+
+	if _, err := n.Int64(); err != nil || !DetectIntegers {
+		_, err = n.Float64()
+		if err != nil {
+			return "", "", err
+		}
+
+		return typeNumber, "", nil
+	}
+
+	return typeInteger, "", nil
+}
+
 func translateStringType(v interface{}) (string, string, error) {
 	t := reflect.TypeOf(v)
 
 	if t.PkgPath() == "encoding/json" && t.Name() == "Number" {
-		n, ok := v.(json.Number)
-		if !ok {
-			return "", "", ErrExpectedNumber
-		}
-
-		if _, err := n.Int64(); err != nil {
-			_, err = n.Float64()
-			if err != nil {
-				return "", "", err
-			}
-
-			return typeNumber, "", nil
-		}
-
-		return typeInteger, "", nil
+		return parseNumber(v)
 	}
 
 	s, ok := v.(string)
@@ -87,17 +96,19 @@ func translateStringType(v interface{}) (string, string, error) {
 		return "", "", ErrExpectedString
 	}
 
-	if parseDateTime(s) {
+	if parseDateTime(s) && DetectTimes {
 		return typeString, formatDateTime, nil
 	}
 
-	if _, err := uuid.Parse(s); err == nil {
+	if _, err := uuid.Parse(s); err == nil && DetectUUIDs {
 		return typeString, formatUUID, nil
 	}
 
-	b := make([]byte, base64.StdEncoding.DecodedLen(len(s)))
-	if _, err := base64.StdEncoding.Decode(b, []byte(s)); err == nil {
-		return typeString, formatByte, nil
+	if len(s) != 0 && DetectByteArrays {
+		b := make([]byte, base64.StdEncoding.DecodedLen(len(s)))
+		if _, err := base64.StdEncoding.Decode(b, []byte(s)); err == nil {
+			return typeString, formatByte, nil
+		}
 	}
 
 	return typeString, "", nil
@@ -123,7 +134,8 @@ func translateType(v interface{}) (string, string, error) {
 	}
 }
 
-func extendedStringType(oldType string, oldFormat string, newType string, newFormat string) (string, string, error) {
+func extendedStringType(name string, oldType string, oldFormat string, newType string, newFormat string,
+) (string, string, error) {
 	if newFormat == "" {
 		switch {
 		case oldFormat == formatByte:
@@ -137,7 +149,7 @@ func extendedStringType(oldType string, oldFormat string, newType string, newFor
 		return oldType, oldFormat, nil
 	}
 
-	return "", "", ErrIncompatibleSchema
+	return "", "", fmt.Errorf("%w field: %s", ErrIncompatibleSchema, name)
 }
 
 // this is only matter for initial schema inference, where we have luxury to extend the type
@@ -147,7 +159,8 @@ func extendedStringType(oldType string, oldFormat string, newType string, newFor
 // byte -> string
 // time -> string
 // uuid => string.
-func extendedType(oldType string, oldFormat string, newType string, newFormat string) (string, string, error) {
+func extendedType(name string, oldType string, oldFormat string, newType string, newFormat string,
+) (string, string, error) {
 	if oldType == typeInteger && newType == typeNumber {
 		return newType, newFormat, nil
 	}
@@ -157,7 +170,7 @@ func extendedType(oldType string, oldFormat string, newType string, newFormat st
 	}
 
 	if oldType == typeString && newType == typeString {
-		if t, f, err := extendedStringType(oldType, oldFormat, newType, newFormat); err == nil {
+		if t, f, err := extendedStringType(name, oldType, oldFormat, newType, newFormat); err == nil {
 			return t, f, nil
 		}
 	}
@@ -166,13 +179,13 @@ func extendedType(oldType string, oldFormat string, newType string, newFormat st
 		return newType, newFormat, nil
 	}
 
-	log.Debug().Str("oldType", oldType).Str("newType", newType).Msg("incompatible schema")
-	log.Debug().Str("oldFormat", oldFormat).Str("newFormat", newFormat).Msg("incompatible schema")
+	log.Debug().Str("oldType", oldType).Str("newType", newType).Str("field_name", name).Msg("incompatible schema")
+	log.Debug().Str("oldFormat", oldFormat).Str("newFormat", newFormat).Str("field_name", name).Msg("incompatible schema")
 
-	return "", "", ErrIncompatibleSchema
+	return "", "", fmt.Errorf("%w field: %s", ErrIncompatibleSchema, name)
 }
 
-func traverseObject(existingField *schema.Field, newField *schema.Field, values map[string]any) error {
+func traverseObject(name string, existingField *schema.Field, newField *schema.Field, values map[string]any) error {
 	switch {
 	case existingField == nil:
 		newField.Fields = make(map[string]*schema.Field)
@@ -186,13 +199,13 @@ func traverseObject(existingField *schema.Field, newField *schema.Field, values 
 		log.Debug().Str("oldType", existingField.Type).Str("newType", newField.Type).Interface("values", values).
 			Msg("object converted to primitive")
 
-		return ErrIncompatibleSchema
+		return fmt.Errorf("%w field: %s", ErrIncompatibleSchema, name)
 	}
 
 	return traverseFields(newField.Fields, values, nil)
 }
 
-func traverseArray(existingField *schema.Field, newField *schema.Field, v any) error {
+func traverseArray(name string, existingField *schema.Field, newField *schema.Field, v any) error {
 	for i := 0; i < reflect.ValueOf(v).Len(); i++ {
 		t, format, err := translateType(reflect.ValueOf(v).Index(i).Interface())
 		if err != nil {
@@ -209,11 +222,11 @@ func traverseArray(existingField *schema.Field, newField *schema.Field, v any) e
 				log.Debug().Str("oldType", existingField.Type).Str("newType", newField.Type).Interface("values", v).
 					Msg("object converted to primitive")
 
-				return ErrIncompatibleSchema
+				return fmt.Errorf("%w field: %s", ErrIncompatibleSchema, name)
 			}
 		}
 
-		nt, nf, err := extendedType(newField.Items.Type, newField.Items.Format, t, format)
+		nt, nf, err := extendedType(name, newField.Items.Type, newField.Items.Format, t, format)
 		if err != nil {
 			return err
 		}
@@ -223,7 +236,7 @@ func traverseArray(existingField *schema.Field, newField *schema.Field, v any) e
 
 		if t == typeObject {
 			values, _ := reflect.ValueOf(v).Index(i).Interface().(map[string]any)
-			if err = traverseObject(newField.Items, newField.Items, values); err != nil {
+			if err = traverseObject(name, newField.Items, newField.Items, values); err != nil {
 				return err
 			}
 
@@ -247,12 +260,12 @@ func setAutoGenerate(autoGen []string, name string, field *schema.Field) {
 	}
 }
 
-func traverseFieldsLow(t string, format string, k string, f *schema.Field, v any, sch map[string]*schema.Field,
+func traverseFieldsLow(t string, format string, name string, f *schema.Field, v any, sch map[string]*schema.Field,
 ) (bool, error) {
 	switch {
 	case t == typeObject:
 		vm, _ := v.(map[string]any)
-		if err := traverseObject(sch[k], f, vm); err != nil {
+		if err := traverseObject(name, sch[name], f, vm); err != nil {
 			return false, err
 		}
 
@@ -265,15 +278,15 @@ func traverseFieldsLow(t string, format string, k string, f *schema.Field, v any
 			return true, nil // empty array does not reflect in the schema
 		}
 
-		if err := traverseArray(sch[k], f, v); err != nil {
+		if err := traverseArray(name, sch[name], f, v); err != nil {
 			return false, err
 		}
 
 		if f.Items == nil {
 			return true, nil // empty object
 		}
-	case sch[k] != nil:
-		nt, nf, err := extendedType(sch[k].Type, sch[k].Format, t, format)
+	case sch[name] != nil:
+		nt, nf, err := extendedType(name, sch[name].Type, sch[name].Format, t, format)
 		if err != nil {
 			return false, err
 		}
@@ -286,20 +299,20 @@ func traverseFieldsLow(t string, format string, k string, f *schema.Field, v any
 }
 
 func traverseFields(sch map[string]*schema.Field, fields map[string]any, autoGen []string) error {
-	for k, v := range fields {
+	for name, val := range fields {
 		// handle `null` JSON value
-		if v == nil {
+		if val == nil {
 			continue
 		}
 
-		t, format, err := translateType(v)
+		t, format, err := translateType(val)
 		if err != nil {
 			return err
 		}
 
 		f := &schema.Field{Type: t, Format: format}
 
-		skip, err := traverseFieldsLow(t, format, k, f, v, sch)
+		skip, err := traverseFieldsLow(t, format, name, f, val, sch)
 		if err != nil {
 			return err
 		}
@@ -308,9 +321,9 @@ func traverseFields(sch map[string]*schema.Field, fields map[string]any, autoGen
 			continue
 		}
 
-		setAutoGenerate(autoGen, k, f)
+		setAutoGenerate(autoGen, name, f)
 
-		sch[k] = f
+		sch[name] = f
 	}
 
 	return nil

--- a/schema/inference_test.go
+++ b/schema/inference_test.go
@@ -17,6 +17,7 @@ package schema
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 	"unsafe"
 
@@ -295,6 +296,8 @@ func TestSchemaInference(t *testing.T) {
 		},
 	}
 
+	DetectByteArrays = true
+
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			var sch schema.Schema
@@ -318,7 +321,7 @@ func TestSchemaInferenceNegative(t *testing.T) {
 				[]byte(`{ "incompatible_field" : 1 }`),
 				[]byte(`{ "incompatible_field" : "1ed6ff32-4c0f-4553-9cd3-a2ea3d58e9d1" }`),
 			},
-			ErrIncompatibleSchema,
+			fmt.Errorf("%w field: %s", ErrIncompatibleSchema, "incompatible_field"),
 		},
 		{
 			"incompatible_prim_to_object",
@@ -326,7 +329,7 @@ func TestSchemaInferenceNegative(t *testing.T) {
 				[]byte(`{ "incompatible_field" : 1 }`),
 				[]byte(`{ "incompatible_field" : { "field1": "1ed6ff32-4c0f-4553-9cd3-a2ea3d58e9d1" } }`),
 			},
-			ErrIncompatibleSchema,
+			fmt.Errorf("%w field: %s", ErrIncompatibleSchema, "incompatible_field"),
 		},
 		{
 			"incompatible_object_to_prim",
@@ -334,7 +337,7 @@ func TestSchemaInferenceNegative(t *testing.T) {
 				[]byte(`{ "incompatible_field" : { "field1": "1ed6ff32-4c0f-4553-9cd3-a2ea3d58e9d1" } }`),
 				[]byte(`{ "incompatible_field" : 1 }`),
 			},
-			ErrIncompatibleSchema,
+			fmt.Errorf("%w field: %s", ErrIncompatibleSchema, "incompatible_field"),
 		},
 		{
 			"incompatible_array_to_prim",
@@ -342,7 +345,7 @@ func TestSchemaInferenceNegative(t *testing.T) {
 				[]byte(`{ "incompatible_field" : ["1ed6ff32-4c0f-4553-9cd3-a2ea3d58e9d1"] }`),
 				[]byte(`{ "incompatible_field" : 1 }`),
 			},
-			ErrIncompatibleSchema,
+			fmt.Errorf("%w field: %s", ErrIncompatibleSchema, "incompatible_field"),
 		},
 		{
 			"incompatible_prim_to_array",
@@ -350,14 +353,14 @@ func TestSchemaInferenceNegative(t *testing.T) {
 				[]byte(`{ "incompatible_field" : 1 }`),
 				[]byte(`{ "incompatible_field" : ["1ed6ff32-4c0f-4553-9cd3-a2ea3d58e9d1"] }`),
 			},
-			ErrIncompatibleSchema,
+			fmt.Errorf("%w field: %s", ErrIncompatibleSchema, "incompatible_field"),
 		},
 		{
 			"incompatible_array_mixed",
 			[][]byte{
 				[]byte(`{ "incompatible_field" : ["1ed6ff32-4c0f-4553-9cd3-a2ea3d58e9d1", 1] }`),
 			},
-			ErrIncompatibleSchema,
+			fmt.Errorf("%w field: %s", ErrIncompatibleSchema, "incompatible_field"),
 		},
 		{
 			"incompatible_array",
@@ -365,14 +368,14 @@ func TestSchemaInferenceNegative(t *testing.T) {
 				[]byte(`{ "incompatible_field" : [ 1 ] }`),
 				[]byte(`{ "incompatible_field" : ["1ed6ff32-4c0f-4553-9cd3-a2ea3d58e9d1"] }`),
 			},
-			ErrIncompatibleSchema,
+			fmt.Errorf("%w field: %s", ErrIncompatibleSchema, "incompatible_field"),
 		},
 		{
 			"incompatible_array_object_mixed",
 			[][]byte{
 				[]byte(`{ "incompatible_field" : [ { "one" : "1ed6ff32-4c0f-4553-9cd3-a2ea3d58e9d1" }, { "one" : 1 } ] }`),
 			},
-			ErrIncompatibleSchema,
+			fmt.Errorf("%w field: %s", ErrIncompatibleSchema, "one"),
 		},
 		{
 			"incompatible_array_object",
@@ -380,7 +383,7 @@ func TestSchemaInferenceNegative(t *testing.T) {
 				[]byte(`{ "incompatible_field" : [ { "one" : "1ed6ff32-4c0f-4553-9cd3-a2ea3d58e9d1" } ] }`),
 				[]byte(`{ "incompatible_field" : [ { "one" : 1 } ] }`),
 			},
-			ErrIncompatibleSchema,
+			fmt.Errorf("%w field: %s", ErrIncompatibleSchema, "one"),
 		},
 		{
 			"incompatible_object",
@@ -388,7 +391,7 @@ func TestSchemaInferenceNegative(t *testing.T) {
 				[]byte(`{ "incompatible_field" : { "one" : 1 } }`),
 				[]byte(`{ "incompatible_field" : { "one" : "1ed6ff32-4c0f-4553-9cd3-a2ea3d58e9d1" } }`),
 			},
-			ErrIncompatibleSchema,
+			fmt.Errorf("%w field: %s", ErrIncompatibleSchema, "one"),
 		},
 	}
 

--- a/tests/backup.sh
+++ b/tests/backup.sh
@@ -18,7 +18,7 @@ test_backup() {
   $cli create project "${TESTDB}"
 
   # Add test data
-  cat <<EOF | TIGRIS_LOG_LEVEL=debug $cli import "--project=${TESTDB}" "${TESTCOLL}" --primary-key=uuid_field --autogenerate=uuid_field
+  cat <<EOF | TIGRIS_LOG_LEVEL=debug $cli import --detect-byte-arrays "--project=${TESTDB}" "${TESTCOLL}" --primary-key=uuid_field --autogenerate=uuid_field
 {
 	"str_field" : "str_value",
 	"int_field" : 1,

--- a/tests/import.sh
+++ b/tests/import.sh
@@ -32,7 +32,7 @@ test_import_null() {
 }
 
 test_import_all_types() {
-  cat <<EOF | TIGRIS_LOG_LEVEL=debug $cli import --project=db_import_test import_test --primary-key=uuid_field --autogenerate=uuid_field
+  cat <<EOF | TIGRIS_LOG_LEVEL=debug $cli import --detect-byte-arrays=true --project=db_import_test import_test --primary-key=uuid_field --autogenerate=uuid_field
 {
 	"str_field" : "str_value",
 	"int_field" : 1,
@@ -314,10 +314,10 @@ test_import() {
 }
 
 test_csv_import_all_types() {
-  cat <<EOF | TIGRIS_LOG_LEVEL=debug $cli import --project=db_import_test import_test_csv --primary-key=uuid_field --autogenerate=uuid_field
+  cat <<EOF | TIGRIS_LOG_LEVEL=debug $cli import --detect-byte-arrays=true --project=db_import_test import_test_csv --primary-key=uuid_field --autogenerate=uuid_field
 str_field,int_field,float_field,uuid_field,time_field,bool_field,binary_field,objects.str_field,objects.int_field,objects.float_field,objects.uuid_field,objects.time_field,objects.bool_field,objects.binary_field,arrays.str_field,arrays.int_field,arrays.float_field,arrays.uuid_field,arrays.time_field,arrays.bool_field,arrays.binary_field
 str_value,1,1.1,1ed6ff32-4c0f-4553-9cd3-a2ea3d58e9d1,2022-11-04T16:17:23.967964263-07:00,true,cGVlay1hLWJvbwo=,str_value,1,1.1,1ed6ff32-4c0f-4553-9cd3-a2ea3d58e9d1,2022-11-04T16:17:23.967964263-07:00,true,cGVlay1hLWJvbwo=,str_value,1,1.1,1ed6ff32-4c0f-4553-9cd3-a2ea3d58e9d1,2022-11-04T16:17:23.967964263-07:00,true,cGVlay1hLWJvbwo=
-str_value,2,2.1,"2ed6ff32-4c0f-4553-9cd3-a2ea3d58e9d1","2012-11-04T16:17:23.967964263-07:00",false,"",,0,3.1,"1ed6ff32-4c0f-4554-9cd3-a2ea3d58e9d1","2002-11-04T16:17:23.967964263-07:00",false,"cGVlay1hLWJvbwo=","str_value",3,4.1,"5ed6ff32-4c0f-4553-9cd3-a2ea3d58e9d1","2000-11-04T16:17:23.967964263-07:00",true,"cGVlay1hLWJvbwo="
+str_value,2,2.1,"2ed6ff32-4c0f-4553-9cd3-a2ea3d58e9d1","2012-11-04T16:17:23.967964263-07:00",false,cGVlay1hLWJvbwo=,,0,3.1,"1ed6ff32-4c0f-4554-9cd3-a2ea3d58e9d1","2002-11-04T16:17:23.967964263-07:00",false,"cGVlay1hLWJvbwo=","str_value",3,4.1,"5ed6ff32-4c0f-4553-9cd3-a2ea3d58e9d1","2000-11-04T16:17:23.967964263-07:00",true,"cGVlay1hLWJvbwo="
 EOF
 
   exp_out='{

--- a/util/import.go
+++ b/util/import.go
@@ -21,6 +21,17 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+func cleanupArrayNULLValuesLow(a []any) {
+	for _, v := range a {
+		switch val := v.(type) {
+		case map[string]any:
+			cleanupNULLValuesLow(val)
+		case []any:
+			cleanupArrayNULLValuesLow(val)
+		}
+	}
+}
+
 func cleanupNULLValuesLow(m map[string]any) {
 	for k, v := range m {
 		switch val := v.(type) {
@@ -30,6 +41,8 @@ func cleanupNULLValuesLow(m map[string]any) {
 			if len(val) == 0 {
 				log.Debug().Str("name", k).Msg("removed empty array")
 				delete(m, k)
+			} else {
+				cleanupArrayNULLValuesLow(val)
 			}
 		case nil:
 			log.Debug().Str("name", k).Msg("removed empty value")


### PR DESCRIPTION
* Fix recursive NULLs cleanup
* Show field name in incompatible schema error message
* Do not consider empty string as byte array
* Disable byte array inference by default
* Allow to control inference of UUIDs, Times, Integers
* Strip debug information from the binary