### PR TITLE
fix: unzip zip archive on Windows install

### DIFF
--- a/pkg/npm/package.json
+++ b/pkg/npm/package.json
@@ -35,6 +35,7 @@
     ],
     "homepage": "https://www.tigrisdata.com",
     "dependencies": {
+        "adm-zip": "^0.5.10",
         "mkdirp": "^1.0.4",
         "node-fetch": "^2.6.7",
         "tar": "^6.1.12"


### PR DESCRIPTION
This isn't the prettiest of solutions. I tried to encapsulate the unarchiving in a function that was passed into the `pipe`, but various things got in my way:

- `tar.x` uses a `end` event but other streams seem to use `finish`
- The support for Node streams + Windows unzipping doesn't seem to be great. [unzipper](https://www.npmjs.com/package/unzipper) was promising, but the .exe it extracted seemed to be corrupted and wouldn't run.

This solution is slightly ugly, but hopefully, the functionality is clear.

I'm creating this PR as a draft as I'm submitting it from a Windows machine and haven't tested how the changes impact *nix installs. If CI tests the install process for *nix then it's probably safe to convert to a full PR.