### PR TITLE
fix: Remove bin/tigris placeholder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,6 @@ lint:
 	golangci-lint run --fix
 	shellcheck tests/*.sh
 	cd pkg/npm && TIGRIS_SKIP_VERIFY=1 npm i; npx eslint install.js
-	git checkout pkg/npm/bin/tigris # lints above overwrites placeholder with real binary
 
 go.sum: go.mod
 	go mod download

--- a/pkg/npm/bin/tigris
+++ b/pkg/npm/bin/tigris
@@ -1,4 +1,0 @@
-#!/ usr / bin / env node
-
-/* eslint-disable no-console */
-console.error('This is placeholder, which should be replaced by installation process');


### PR DESCRIPTION
## tl;dr

Removing the `pkg/npm/bin/tigris` should fix a problem on Windows where the npm CLI installation creates a malformed shim. This file isn't present in the Windows zip installation archive and isn't required for Windows installs.

## Details

We've made progress on supporting installation via NPM on Windows. However, I've just gotten to the bottom of a very obscure problem.

When the npm CLI installs a package, it runs a shim function to create shell and Powershell scripts that call the underlying installed binary.

![image](https://github.com/tigrisdata/tigris-cli/assets/328367/4003b360-b35a-4bb4-b6f3-272704222055)

This shim function checks for the presence of a `bin/${prog}`, and if found, reads the file to see if there's a shebang. It makes (potentially valid) assumptions about that file and the format of the shebang. See https://github.com/npm/cmd-shim/blob/main/lib/index.js#L51-L59

However, this file shouldn't exist on Windows - at least on our installation. Instead, there should only be a `tigris.exe`. The fact that the placeholder `tigris` file exists then sends the Powershell shim wrapping logic in the wrong direction resulting in a generated `tigris.ps1`:

```pwsh
#!/usr/bin/env pwsh
$basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent

$exe=""
if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
  # Fix case when both the Windows and Linux builds of Node
  # are installed in the same directory
  $exe=".exe"
}
$ret=0
if (Test-Path "$basedir//$exe") {
  # Support pipeline input
  if ($MyInvocation.ExpectingInput) {
    $input | & "$basedir//$exe" usr / bin / env node "$basedir/../@tigrisdata/tigris-cli/bin/tigris" $args
  } else {
    & "$basedir//$exe" usr / bin / env node "$basedir/../@tigrisdata/tigris-cli/bin/tigris" $args
  }
  $ret=$LASTEXITCODE
} else {
  # Support pipeline input
  if ($MyInvocation.ExpectingInput) {
    $input | & "/$exe" usr / bin / env node "$basedir/../@tigrisdata/tigris-cli/bin/tigris" $args
  } else {
    & "/$exe" usr / bin / env node "$basedir/../@tigrisdata/tigris-cli/bin/tigris" $args
  }
  $ret=$LASTEXITCODE
}
exit $ret
```

In the above script, `$basedir//$exe` doesn't make any sense. This results in the following error when running the `tigris` command:

```pwsh
PS C:\Users\phil\tigris\tmp> tigris
& : The term '/.exe' is not recognized as the name of a cmdlet, function, script file, or operable program. Check the
spelling of the name, or if a path was included, verify that the path is correct and try again.
At C:\Users\phil\AppData\Roaming\npm\tigris.ps1:24 char:7
+     & "/$exe" usr / bin / env node "$basedir/node_modules/@tigrisdata ...
+       ~~~~~~~
    + CategoryInfo          : ObjectNotFound: (/.exe:String) [], CommandNotFoundException
    + FullyQualifiedErrorId : CommandNotFoundException
```

Removing the placeholder file will mean the shim logic takes a different path and will call [`writeShim_(from, to)`](https://github.com/npm/cmd-shim/blob/main/lib/index.js#L53).