### PR TITLE
Fix float numbers for search on import

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -114,7 +114,7 @@ func Infof(format string, args ...interface{}) {
 }
 
 func Error(err error, msg string, args ...interface{}) error {
-	log.Err(err).CallerSkipFrame(3).Msgf(msg, args...)
+	log.Err(err).CallerSkipFrame(2).Msgf(msg, args...)
 
 	if err == nil {
 		return nil


### PR DESCRIPTION
This change detects if document contains array of objects in the schema, and if it is the case replaces all the numbers to fractional value, in order to guarantee that search infer their schema as float.

It inserts this record with replaced numbers for search to persists proper schema and deletes the record immediately.

It proceeds import process as usual after that