### PR TITLE
feat: Allow to skip local TLS when token is set

### DIFF
--- a/.github/workflows/go-releaser.yaml
+++ b/.github/workflows/go-releaser.yaml
@@ -35,7 +35,7 @@ jobs:
           node-version: 18
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Genearate shell completions
+      - name: Generate shell completions
         run: |
           make
           mkdir -p .tmp

--- a/client/driver.go
+++ b/client/driver.go
@@ -46,10 +46,11 @@ func initConfig(inCfg *config.Config) {
 		Token:        inCfg.Token,
 		Protocol:     inCfg.Protocol,
 		Branch:       inCfg.Branch,
+		SkipLocalTLS: inCfg.SkipLocalTLS,
 	}
 
-	if inCfg.UseTLS || (cfg.URL == "" && cfg.Protocol == "") ||
-		strings.HasSuffix(cfg.URL, config.Domain) {
+	if !cfg.SkipLocalTLS && (inCfg.UseTLS || (cfg.URL == "" && cfg.Protocol == "") ||
+		strings.HasSuffix(cfg.URL, config.Domain)) {
 		cfg.TLS = &tls.Config{MinVersion: tls.VersionTLS12}
 	}
 }

--- a/cmd/local.go
+++ b/cmd/local.go
@@ -185,7 +185,8 @@ func waitServerUp(port string) {
 	err := tclient.Init(&cfg)
 	util.Fatal(err, "init tigris client")
 
-	if err := pingLow(context.Background(), waitUpTimeout, pingSleepTimeout, true); err != nil {
+	if err = pingLow(context.Background(), waitUpTimeout, pingSleepTimeout, true, true,
+		util.IsTTY(os.Stdout) && !util.Quiet); err != nil {
 		util.Fatal(err, "tigris initialization failed")
 	}
 
@@ -236,7 +237,7 @@ var serverUpCmd = &cobra.Command{
 		}
 
 		if loginParam {
-			login.LocalLogin(net.JoinHostPort("localhost", port))
+			login.LocalLogin(net.JoinHostPort("localhost", port), "")
 		} else if port != "8081" {
 			util.Stdoutf("run 'export TIGRIS_URL=localhost:%s' for tigris cli to connect to the local instance\n", port)
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -44,16 +44,19 @@ type Log struct {
 }
 
 type Config struct {
-	ClientID     string        `json:"client_id" yaml:"client_id,omitempty" mapstructure:"client_id"`
-	ClientSecret string        `json:"client_secret" yaml:"client_secret,omitempty" mapstructure:"client_secret"`
-	Token        string        `json:"token" yaml:"token,omitempty"`
-	URL          string        `json:"url" yaml:"url,omitempty"`
-	Protocol     string        `json:"protocol" yaml:"protocol,omitempty"`
-	Project      string        `json:"project" yaml:"project,omitempty"`
-	Branch       string        `json:"branch" yaml:"branch,omitempty"`
+	ClientID     string `json:"client_id" yaml:"client_id,omitempty" mapstructure:"client_id"`
+	ClientSecret string `json:"client_secret" yaml:"client_secret,omitempty" mapstructure:"client_secret"`
+	Token        string `json:"token" yaml:"token,omitempty"`
+	URL          string `json:"url" yaml:"url,omitempty"`
+	Protocol     string `json:"protocol" yaml:"protocol,omitempty"`
+	Project      string `json:"project" yaml:"project,omitempty"`
+	Branch       string `json:"branch" yaml:"branch,omitempty"`
+	DataDir      string `json:"data_dir" yaml:"data_dir,omitempty"`
+
 	Log          Log           `json:"log" yaml:"log,omitempty"`
 	Timeout      time.Duration `json:"timeout" yaml:"timeout,omitempty"`
 	UseTLS       bool          `json:"use_tls" yaml:"use_tls,omitempty" mapstructure:"use_tls"`
+	SkipLocalTLS bool          `json:"skip_local_tls" yaml:"skip_local_tls,omitempty" mapstructure:"skip_local_tls"`
 }
 
 var DefaultName = "tigris-cli"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tigrisdata/tigris-cli
 
-go 1.18
+go 1.20
 
 require (
 	github.com/coreos/go-oidc/v3 v3.5.0
@@ -19,7 +19,7 @@ require (
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/viper v1.15.0
 	github.com/stretchr/testify v1.8.2
-	github.com/tigrisdata/tigris-client-go v1.0.0
+	github.com/tigrisdata/tigris-client-go v1.1.0-next.6
 	golang.org/x/net v0.10.0
 	golang.org/x/oauth2 v0.8.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -355,8 +355,8 @@ github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/subosito/gotenv v1.4.2 h1:X1TuBLAMDFbaTAChgCBLu3DU3UPyELpnF2jjJ2cz/S8=
 github.com/subosito/gotenv v1.4.2/go.mod h1:ayKnFf/c6rvx/2iiLrJUk1e6plDbT3edrFNGqEflhK0=
-github.com/tigrisdata/tigris-client-go v1.0.0 h1:07Qw8Tm0qL15WiadP0hp4iBiRzfNSJ+GH4/ozO0nNs0=
-github.com/tigrisdata/tigris-client-go v1.0.0/go.mod h1:2n6TQUdoTbzuTtakHT/ZNuK5X+I/i57BqqCcYAzG7y4=
+github.com/tigrisdata/tigris-client-go v1.1.0-next.6 h1:Bkr74x8uXeArEbTI5osyLsPyRwK07TzwtXqvydmW/fY=
+github.com/tigrisdata/tigris-client-go v1.1.0-next.6/go.mod h1:2n6TQUdoTbzuTtakHT/ZNuK5X+I/i57BqqCcYAzG7y4=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=
 github.com/xanzy/ssh-agent v0.3.3/go.mod h1:6dzNDKs0J9rVPHPhaGCukekBHKqfl+L3KghI1Bc68Uw=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=

--- a/schema/inference_test.go
+++ b/schema/inference_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/tigrisdata/tigris-client-go/schema"
 )
 
+//nolint:maintidx
 func TestSchemaInference(t *testing.T) {
 	cases := []struct {
 		name string
@@ -65,47 +66,47 @@ func TestSchemaInference(t *testing.T) {
 			}, exp: &schema.Schema{
 				Name: "types",
 				Fields: map[string]*schema.Field{
-					"uuid_field":   {Type: "string", Format: "uuid"},
-					"time_field":   {Type: "string", Format: "date-time"},
-					"str_field":    {Type: "string"},
-					"bool_field":   {Type: "boolean"},
-					"float_field":  {Type: "number"},
-					"int_field":    {Type: "integer"},
-					"binary_field": {Type: "string", Format: "byte"},
-					"object": {Type: "object", Fields: map[string]*schema.Field{
-						"uuid_field":   {Type: "string", Format: "uuid"},
-						"time_field":   {Type: "string", Format: "date-time"},
-						"str_field":    {Type: "string"},
-						"bool_field":   {Type: "boolean"},
-						"float_field":  {Type: "number"},
-						"int_field":    {Type: "integer"},
-						"binary_field": {Type: "string", Format: "byte"},
+					"uuid_field":   {Type: schema.NewMultiType(typeString), Format: "uuid"},
+					"time_field":   {Type: schema.NewMultiType(typeString), Format: "date-time"},
+					"str_field":    {Type: schema.NewMultiType(typeString)},
+					"bool_field":   {Type: schema.NewMultiType(typeBoolean)},
+					"float_field":  {Type: schema.NewMultiType(typeNumber)},
+					"int_field":    {Type: schema.NewMultiType(typeInteger)},
+					"binary_field": {Type: schema.NewMultiType(typeString), Format: "byte"},
+					"object": {Type: schema.NewMultiType(typeObject), Fields: map[string]*schema.Field{
+						"uuid_field":   {Type: schema.NewMultiType(typeString), Format: "uuid"},
+						"time_field":   {Type: schema.NewMultiType(typeString), Format: "date-time"},
+						"str_field":    {Type: schema.NewMultiType(typeString)},
+						"bool_field":   {Type: schema.NewMultiType(typeBoolean)},
+						"float_field":  {Type: schema.NewMultiType(typeNumber)},
+						"int_field":    {Type: schema.NewMultiType(typeInteger)},
+						"binary_field": {Type: schema.NewMultiType(typeString), Format: "byte"},
 					}},
 					"array": {
-						Type: "array",
+						Type: schema.NewMultiType(typeArray),
 						Items: &schema.Field{
-							Type: "object",
+							Type: schema.NewMultiType(typeObject),
 							Fields: map[string]*schema.Field{
-								"uuid_field":   {Type: "string", Format: "uuid"},
-								"time_field":   {Type: "string", Format: "date-time"},
-								"str_field":    {Type: "string"},
-								"bool_field":   {Type: "boolean"},
-								"float_field":  {Type: "number"},
-								"int_field":    {Type: "integer"},
-								"binary_field": {Type: "string", Format: "byte"},
+								"uuid_field":   {Type: schema.NewMultiType(typeString), Format: "uuid"},
+								"time_field":   {Type: schema.NewMultiType(typeString), Format: "date-time"},
+								"str_field":    {Type: schema.NewMultiType(typeString)},
+								"bool_field":   {Type: schema.NewMultiType(typeBoolean)},
+								"float_field":  {Type: schema.NewMultiType(typeNumber)},
+								"int_field":    {Type: schema.NewMultiType(typeInteger)},
+								"binary_field": {Type: schema.NewMultiType(typeString), Format: "byte"},
 							},
 						},
 					},
 					"prim_array": {
-						Type: "array",
+						Type: schema.NewMultiType(typeArray),
 						Items: &schema.Field{
-							Type: "string",
+							Type: schema.NewMultiType(typeString),
 						},
 					},
 					"array_uuid": {
-						Type: "array",
+						Type: schema.NewMultiType(typeArray),
 						Items: &schema.Field{
-							Type:   typeString,
+							Type:   schema.NewMultiType(typeString),
 							Format: formatUUID,
 						},
 					},
@@ -126,8 +127,8 @@ func TestSchemaInference(t *testing.T) {
 			}, exp: &schema.Schema{
 				Name: "empty_obj_arr",
 				Fields: map[string]*schema.Field{
-					"int_field": {Type: "integer"},
-					"str_field": {Type: "string"},
+					"int_field": {Type: schema.NewMultiType(typeInteger)},
+					"str_field": {Type: schema.NewMultiType(typeString)},
 				},
 			},
 		},
@@ -173,25 +174,25 @@ func TestSchemaInference(t *testing.T) {
 			}, exp: &schema.Schema{
 				Name: "broaden_type",
 				Fields: map[string]*schema.Field{
-					"uuid_field":   {Type: "string"},
-					"time_field":   {Type: "string"},
-					"int_field":    {Type: "number"},
-					"binary_field": {Type: "string"},
-					"object": {Type: "object", Fields: map[string]*schema.Field{
-						"uuid_field":   {Type: "string"},
-						"time_field":   {Type: "string"},
-						"int_field":    {Type: "number"},
-						"binary_field": {Type: "string"},
+					"uuid_field":   {Type: schema.NewMultiType(typeString)},
+					"time_field":   {Type: schema.NewMultiType(typeString)},
+					"int_field":    {Type: schema.NewMultiType(typeNumber)},
+					"binary_field": {Type: schema.NewMultiType(typeString)},
+					"object": {Type: schema.NewMultiType(typeObject), Fields: map[string]*schema.Field{
+						"uuid_field":   {Type: schema.NewMultiType(typeString)},
+						"time_field":   {Type: schema.NewMultiType(typeString)},
+						"int_field":    {Type: schema.NewMultiType(typeNumber)},
+						"binary_field": {Type: schema.NewMultiType(typeString)},
 					}},
 					"array": {
-						Type: "array",
+						Type: schema.NewMultiType(typeArray),
 						Items: &schema.Field{
-							Type: "object",
+							Type: schema.NewMultiType(typeObject),
 							Fields: map[string]*schema.Field{
-								"uuid_field":   {Type: "string"},
-								"time_field":   {Type: "string"},
-								"int_field":    {Type: "number"},
-								"binary_field": {Type: "string"},
+								"uuid_field":   {Type: schema.NewMultiType(typeString)},
+								"time_field":   {Type: schema.NewMultiType(typeString)},
+								"int_field":    {Type: schema.NewMultiType(typeNumber)},
+								"binary_field": {Type: schema.NewMultiType(typeString)},
 							},
 						},
 					},
@@ -218,14 +219,14 @@ func TestSchemaInference(t *testing.T) {
 				Name: "broaden_array_type",
 				Fields: map[string]*schema.Field{
 					"array": {
-						Type: "array",
+						Type: schema.NewMultiType(typeArray),
 						Items: &schema.Field{
-							Type: "object",
+							Type: schema.NewMultiType(typeObject),
 							Fields: map[string]*schema.Field{
-								"uuid_field":   {Type: "string"},
-								"time_field":   {Type: "string"},
-								"int_field":    {Type: "number"},
-								"binary_field": {Type: "string"},
+								"uuid_field":   {Type: schema.NewMultiType(typeString)},
+								"time_field":   {Type: schema.NewMultiType(typeString)},
+								"int_field":    {Type: schema.NewMultiType(typeNumber)},
+								"binary_field": {Type: schema.NewMultiType(typeString)},
 							},
 						},
 					},
@@ -255,19 +256,19 @@ func TestSchemaInference(t *testing.T) {
 			}, exp: &schema.Schema{
 				Name: "adding_fields",
 				Fields: map[string]*schema.Field{
-					"uuid_field": {Type: "string", Format: formatUUID},
-					"int_field":  {Type: "integer"},
-					"object": {Type: "object", Fields: map[string]*schema.Field{
-						"uuid_field": {Type: "string", Format: formatUUID},
-						"int_field":  {Type: "integer"},
+					"uuid_field": {Type: schema.NewMultiType(typeString), Format: formatUUID},
+					"int_field":  {Type: schema.NewMultiType(typeInteger)},
+					"object": {Type: schema.NewMultiType(typeObject), Fields: map[string]*schema.Field{
+						"uuid_field": {Type: schema.NewMultiType(typeString), Format: formatUUID},
+						"int_field":  {Type: schema.NewMultiType(typeInteger)},
 					}},
 					"array": {
-						Type: "array",
+						Type: schema.NewMultiType(typeArray),
 						Items: &schema.Field{
-							Type: "object",
+							Type: schema.NewMultiType(typeObject),
 							Fields: map[string]*schema.Field{
-								"uuid_field": {Type: "string", Format: formatUUID},
-								"int_field":  {Type: "integer"},
+								"uuid_field": {Type: schema.NewMultiType(typeString), Format: formatUUID},
+								"int_field":  {Type: schema.NewMultiType(typeInteger)},
 							},
 						},
 					},
@@ -281,12 +282,12 @@ func TestSchemaInference(t *testing.T) {
 				Name: "adding_array_object_fields",
 				Fields: map[string]*schema.Field{
 					"array": {
-						Type: "array",
+						Type: schema.NewMultiType(typeArray),
 						Items: &schema.Field{
-							Type: "object",
+							Type: schema.NewMultiType(typeObject),
 							Fields: map[string]*schema.Field{
-								"int_field":     {Type: "integer"},
-								"int_field_two": {Type: "integer"},
+								"int_field":     {Type: schema.NewMultiType(typeInteger)},
+								"int_field_two": {Type: schema.NewMultiType(typeInteger)},
 							},
 						},
 					},
@@ -423,8 +424,8 @@ func TestSchemaTags(t *testing.T) {
 			exp: &schema.Schema{
 				Name: "pk_autogenerate",
 				Fields: map[string]*schema.Field{
-					"uuid_field":  {Type: "string", Format: "uuid"},
-					"uuid_field1": {Type: "string", Format: "uuid", AutoGenerate: true},
+					"uuid_field":  {Type: schema.NewMultiType(typeString), Format: "uuid"},
+					"uuid_field1": {Type: schema.NewMultiType(typeString), Format: "uuid", AutoGenerate: true},
 				},
 				PrimaryKey: []string{"uuid_field"},
 			},
@@ -440,8 +441,8 @@ func TestSchemaTags(t *testing.T) {
 			exp: &schema.Schema{
 				Name: "pk_autogenerate_multi",
 				Fields: map[string]*schema.Field{
-					"uuid_field":  {Type: "string", Format: "uuid", AutoGenerate: true},
-					"uuid_field1": {Type: "string", Format: "uuid", AutoGenerate: true},
+					"uuid_field":  {Type: schema.NewMultiType(typeString), Format: "uuid", AutoGenerate: true},
+					"uuid_field1": {Type: schema.NewMultiType(typeString), Format: "uuid", AutoGenerate: true},
 				},
 				PrimaryKey: []string{"uuid_field", "uuid_field1"},
 			},

--- a/tests/main.sh
+++ b/tests/main.sh
@@ -53,7 +53,7 @@ fi
 
 #shellcheck disable=SC2154
 if [ -z "$noup" ]; then
-	TIGRIS_LOG_LEVEL=debug $cli local up "$TIGRIS_TEST_PORT"
+	TIGRIS_LOG_LEVEL=debug $cli dev start "$TIGRIS_TEST_PORT"
 	$cli local logs >/dev/null 2>&1
 fi
 


### PR DESCRIPTION
By default we enforce TLS if token or secret is set. This feature allow to disable TLS when connecting to local instance with authenticatiaon enabled.
TLS can only be disabled for HTTP.
GRPC always enforce TLS when credentials non empty, it only allows to disble it on Unix sockets.

* Added unix socket support.
* Fixed a bug when user was automatically logged in to local instance with authentication enabled.
* This also updated the client to the latest, which requires inference code updates.